### PR TITLE
fix: add path to tsconfig in alias settings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -86,7 +86,7 @@ export default tseslint.config(
       'import/resolver': {
         typescript: {
           alwaysTryTypes: true,
-          project: path.dirname(fileURLToPath(import.meta.url)),
+          project: path.join(path.dirname(fileURLToPath(import.meta.url)), './tsconfig.json'),
         },
         node: true,
       },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -84,11 +84,7 @@ export default tseslint.config(
         version: 'detect',
       },
       'import/resolver': {
-        typescript: {
-          alwaysTryTypes: true,
-          project: path.join(path.dirname(fileURLToPath(import.meta.url)), './tsconfig.json'),
-        },
-        node: true,
+        typescript: true,
       },
     },
   },


### PR DESCRIPTION
## Summary

<!-- Provide a concise summary "Why are the changes needed"?
Include any relevant links, such as Jira tickets, Slack discussions,
or design documents. -->
Guys, I encountered a bug, the linter complained that it can't resolve a construction like `import { useLoginForm } from '@/feature/auth/login/use-login-form';` because `Unable to resolve path to module '@/feature/auth/login/use-login-form'.eslintimport/no-unresolved`
A quick google showed that you need to add the path to `tsconfig.json`

foreshadowing the question, why `tsconfig.json` if we have two more configs. Answer: Because it's the main config and it combines both `app` and `node`. Although it works with `tsconfig.app.json` too, I checked!
## Changes Made

<!-- Describe the specific changes that have been made in this pull
request. Provide details on the approach taken to address the problem
and any notable implementation details. -->

add path to `tsconfig.json`

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

