### PR TITLE
feat: Add reset page to page=1 when filters are used

### DIFF
--- a/src/feature/catalog/pagination/use-reset-page.ts
+++ b/src/feature/catalog/pagination/use-reset-page.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router';
 
 type UseResetPageDeps = {
@@ -17,22 +17,27 @@ export function useResetPage({
   lastCategoryId,
 }: UseResetPageDeps) {
   const [searchParams, setSearchParams] = useSearchParams();
-
-  useEffect(() => {
-    const page = searchParams.get('page');
-    if (page !== '1') {
-      const newParams = new URLSearchParams(searchParams);
-      newParams.set('page', '1');
-      setSearchParams(newParams);
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
-  }, [
+  const previousFilterValues = useRef('');
+  const currentFilterValues = JSON.stringify({
     selectedTypes,
     onlyDiscounted,
     priceRange,
     sortOption,
     lastCategoryId,
-    searchParams,
-    setSearchParams,
-  ]);
+  });
+
+  useEffect(() => {
+    const currentPage = searchParams.get('page');
+
+    if (currentFilterValues !== previousFilterValues.current) {
+      previousFilterValues.current = currentFilterValues;
+
+      if (currentPage !== '1') {
+        const newParams = new URLSearchParams(searchParams);
+        newParams.set('page', '1');
+        setSearchParams(newParams);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    }
+  }, [currentFilterValues, searchParams, setSearchParams]);
 }

--- a/src/feature/catalog/pagination/use-reset-page.ts
+++ b/src/feature/catalog/pagination/use-reset-page.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router';
+
+type UseResetPageDeps = {
+  selectedTypes: string[];
+  onlyDiscounted: boolean;
+  priceRange: [number, number];
+  sortOption?: string;
+  lastCategoryId: string;
+};
+
+export function useResetPage({
+  selectedTypes,
+  onlyDiscounted,
+  priceRange,
+  sortOption,
+  lastCategoryId,
+}: UseResetPageDeps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    const page = searchParams.get('page');
+    if (page !== '1') {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set('page', '1');
+      setSearchParams(newParams);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [
+    selectedTypes,
+    onlyDiscounted,
+    priceRange,
+    sortOption,
+    lastCategoryId,
+    searchParams,
+    setSearchParams,
+  ]);
+}

--- a/src/pages/catalog-page.tsx
+++ b/src/pages/catalog-page.tsx
@@ -9,6 +9,7 @@ import { CategoryNavigation } from '@/feature/catalog/categories/category-naviga
 import { useCategoryStore } from '@/feature/catalog/categories/use-category-store';
 import { TypeFilter } from '@/feature/catalog/filter/type-filter';
 import { useFilterStore } from '@/feature/catalog/filter/use-filter-store';
+import { useResetPage } from '@/feature/catalog/pagination/use-reset-page';
 import { ProductList } from '@/feature/catalog/product-list';
 import { useSortStore } from '@/feature/catalog/sorting/use-sort-store';
 import type { Poster } from '@/feature/catalog/types';
@@ -26,6 +27,14 @@ export default function CatalogPage() {
   const currentPage = pageParam ? Number(pageParam) : 1;
 
   const { productsPerPage } = config;
+
+  useResetPage({
+    selectedTypes,
+    onlyDiscounted,
+    priceRange,
+    sortOption,
+    lastCategoryId,
+  });
 
   const onPageChange = (page: number) => {
     const newParams = new URLSearchParams(searchParams);


### PR DESCRIPTION
## Summary
Reset page to page=1 are added when filters are used. Now the list of products is displayed correctly after filtering and does not display a message that products were not found

<!-- Provide a concise summary "Why are the changes needed"?
Include any relevant links, such as Jira tickets, Slack discussions,
or design documents. -->

## Changes Made

<!-- Describe the specific changes that have been made in this pull
request. Provide details on the approach taken to address the problem
and any notable implementation details. -->

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!-- Optional Sections -->
<details>
<summary><strong>Expand for optional sections</strong></summary>

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

## Related issues

<!-- A link to any related issues or bugs that the pull request
addresses, connecting the code's context with the problem it
solves. -->

## Testing instructions

<!-- Instructions on how to test the changes made in the pull
request, helping reviewers validate the code. -->

## Special notes for your reviewer

<!-- If there are any specific instructions or considerations you
want to highlight for the reviewer, include them in this section. -->

</details>
<!-- End of Optional Sections -->
